### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine
 LABEL maintainer="nigelpoulton@hotmail.com"
 
 # Install Node and NPM
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update nodejs nodejs-npm curl
 
 # Copy app to /src
 COPY . /src


### PR DESCRIPTION
The kubernetes book, November Edition, page 76 asks one to type `curl localhost:8080`. It is obviously missing :)

(also, the so called 'git repo' is missing)