### PR TITLE
The nodejs-npm is no longer existent in latest Alpine (v3.8+)  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine
 LABEL maintainer="nigelpoulton@hotmail.com"
 
 # Install Node and NPM
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update npm
 
 # Copy app to /src
 COPY . /src


### PR DESCRIPTION
Changed the name of the package nodejs-npm to npm. And then you can successfuly build the image.